### PR TITLE
Switching over to Yakifo/amqtt

### DIFF
--- a/hss_server/mqtt.py
+++ b/hss_server/mqtt.py
@@ -12,8 +12,8 @@ import logging
 import json
 import asyncio
 
-from hbmqtt.client import MQTTClient, ClientException
-from hbmqtt.mqtt.constants import QOS_0
+from amqtt.client import MQTTClient, ClientException
+from amqtt.mqtt.constants import QOS_0
 
 # -----------------------------------------------------------------------------
 # class Mqtt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hbmqtt>=0.9.6
+amqtt>=0.10.0
 requests>=2.22.0
 appdirs>=1.4.3
 gitpython>=3.1.3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-       'hbmqtt',
+       'amqtt',
        'requests',
        'appdirs',
        'GitPython',


### PR DESCRIPTION
Switching over to Yakifo/amqtt since hbmqtt is no longer maintained, and uses old websockets API which has been switched to legacy